### PR TITLE
Make URLs absolute

### DIFF
--- a/dgm-navbar.html
+++ b/dgm-navbar.html
@@ -43,7 +43,7 @@ Example:
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                     </button>
-                    <a class="navbar-brand" title="Ir a la página de inicio de datos.gob.mx" href="/">
+                    <a class="navbar-brand" title="Ir a la página de inicio de datos.gob.mx" href="//datos.gob.mx/">
                         <svg width="141px" height="31px" viewBox="0 0 141 31" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
                             <!-- Generator: Sketch Beta 3.2.2 (9983) - http://www.bohemiancoding.com/sketch -->
                             <title>Logo Datos</title>
@@ -101,16 +101,16 @@ Example:
                             <a aria-label="Ir al catalogo de datos" title="Ir al catalogo de datos" href="http://busca.datos.gob.mx">Datos</a>
                         </li>
                         <li>
-                            <a aria-label="Conoce las herramientas con datos" title="Conoce las herramientas con datos" href="/herramientas">Herramientas</a>
+                            <a aria-label="Conoce las herramientas con datos" title="Conoce las herramientas con datos" href="//datos.gob.mx/herramientas">Herramientas</a>
                         </li>
                         <li>
-                            <a aria-label="Conoce el impacto de los datos" title="Conoce el impacto de los datos" href="/impacto">Impacto</a>
+                            <a aria-label="Conoce el impacto de los datos" title="Conoce el impacto de los datos" href="//datos.gob.mx/impacto">Impacto</a>
                         </li>
                         <li>
-                            <a aria-label="Ir a la guía de datos" title="Ir a la guía de datos" href="/guia">Guía</a>
+                            <a aria-label="Ir a la guía de datos" title="Ir a la guía de datos" href="//datos.gob.mx/guia">Guía</a>
                         </li>
                         <li>
-                            <a aria-label="Conoce más sobre este sitio" title="Conoce más sobre este sitio" href="/acerca">Acerca</a>
+                            <a aria-label="Conoce más sobre este sitio" title="Conoce más sobre este sitio" href="//datos.gob.mx/acerca">Acerca</a>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
Several of the URLs in the navbar assume that the site is being served from `datos.gob.mx` -- this will not always be the case. mxabierto/dgm-footer always uses absolute URLs.

Needed in the context of mxabierto/procurement-analytics